### PR TITLE
MySQL 8.4 no longer has default-authentication-plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     image: docker.io/mysql:8
     ports:
       - "127.0.0.1:3306:3306"
-    command: --default-authentication-plugin=mysql_native_password
+    command: --mysql_native_password=ON
     environment:
       - MYSQL_USER=fts
       - MYSQL_PASSWORD=fts


### PR DESCRIPTION
Instead use `--mysql_native_password=ON`.